### PR TITLE
gitcpup/gitcpur: Add support to GitLab Patch

### DIFF
--- a/android_git.rc
+++ b/android_git.rc
@@ -34,9 +34,11 @@ function gitcpup()
     return;
   fi;
 
-  # GitHub patch
-  if [[ "${tmpurl}" =~ 'github.com' ]] && [[ ! "${tmpurl}" =~ '.patch' ]]; then
-    tmpurl="${tmpurl}.patch";
+  # GitHub/GitLab patch
+  if [[ ! "${tmpurl}" =~ '.patch' ]]; then
+    if [[ "${tmpurl}" =~ 'github.com' ]] || [[ "${tmpurl}" =~ 'gitlab.com' ]]; then
+      tmpurl="${tmpurl}.patch";
+    fi;
   fi;
 
   # CodeAurora patch
@@ -108,9 +110,11 @@ function gitcpur()
   local replace="${4}";
   echo '';
 
-  # GitHub patch
-  if [[ "${tmpurl}" =~ 'github.com' ]] && [[ ! "${tmpurl}" =~ '.patch' ]]; then
-    tmpurl="${tmpurl}.patch";
+  # GitHub/GitLab patch
+  if [[ ! "${tmpurl}" =~ '.patch' ]]; then
+    if [[ "${tmpurl}" =~ 'github.com' ]] || [[ "${tmpurl}" =~ 'gitlab.com' ]]; then
+      tmpurl="${tmpurl}.patch";
+    fi;
   fi;
 
   # Cherry-pick


### PR DESCRIPTION
* It uses same style of GitHub patchs [Tested and worked]

Signed-off-by: Caio Oliveira <caiooliveirafarias0@gmail.com>