### PR TITLE
android_release_cleaners: don't hardcode location of out dir

### DIFF
--- a/android_release_cleaners.rc
+++ b/android_release_cleaners.rc
@@ -66,7 +66,11 @@ function outbootdevcl()
   [ -z "${2}" ] && echo '';
 
   # Out path
-  out_device_path=./out/target/product/${1};
+  if [ -z "${OUT_DIR}" ]; then
+    out_device_path=./out/target/product/${1};
+  else
+    out_device_path="${OUT_DIR}/target/product/${1}";
+  fi
 
   # Rebuild the default properties
   if [ -f "${out_device_path}/ota_temp/RECOVERY/RAMDISK/default.prop" ]; then
@@ -106,7 +110,11 @@ function outotadevcl()
   [ -z "${2}" ] && echo '';
 
   # Out path
-  out_device_path=./out/target/product/${1};
+  if [ -z "${OUT_DIR}" ]; then
+    out_device_path=./out/target/product/${1};
+  else
+    out_device_path="${OUT_DIR}/target/product/${1}";
+  fi
 
   # Delete relevant outputs
   rm -rf "${out_device_path}/"*"${1}"*".zip";
@@ -135,7 +143,11 @@ function outsepdevcl()
   [ -z "${2}" ] && echo '';
 
   # Out path
-  out_device_path=./out/target/product/${1};
+  if [ -z "${OUT_DIR}" ]; then
+    out_device_path=./out/target/product/${1};
+  else
+    out_device_path="${OUT_DIR}/target/product/${1}";
+  fi
 
   # Delete relevant outputs
   rm -f "${out_device_path}/root/file_contexts"*;
@@ -166,7 +178,11 @@ function outsystemdevcl()
   [ -z "${3}" ] && echo '';
 
   # Out path
-  out_device_path=./out/target/product/${1};
+  if [ -z "${OUT_DIR}" ]; then
+    out_device_path=./out/target/product/${1};
+  else
+    out_device_path="${OUT_DIR}/target/product/${1}";
+  fi
 
   # Delete relevant outputs
   if [ -z "${2}" ]; then


### PR DESCRIPTION
* Guys like me have OUT_DIR set to another location, so none of these functions work in that case

Signed-off-by: Akhil Narang <akhilnarang.1999@gmail.com>