### PR TITLE
adbro: replace remount with manual mount

### DIFF
--- a/sources/android_adb/tools.rc
+++ b/sources/android_adb/tools.rc
@@ -151,7 +151,7 @@ function adbro()
   systemaccess=$(echo "${systemmount}" | grep rw);
   if [ ! -z "${systemmount}" ] && [ -z "${systemaccess}" ]; then
     adbwait;
-    ${adb_timeout} 'remount';
+    ${adb_timeout} shell 'mount -o rw,remount -t auto /system';
     sleep 1;
     adbwait;
   fi;


### PR DESCRIPTION
A/B devices don't work with adb remount. Replace remount logic
with acceptable one, until a better solution is found.

Change-Id: I627ca29739c72a5020bd89442b6d6739fa18608e